### PR TITLE
fix in autorun, html instantiated before nodejs

### DIFF
--- a/cra-template-brightsign-app/template/src/autorun.brs
+++ b/cra-template-brightsign-app/template/src/autorun.brs
@@ -8,12 +8,12 @@ function main()
   ' Enable SSH
   enableSSH()
 
+  ' Initialize roNodeJs with path or correct filename, whether webpack is used or not.
+  node_js = CreateObject("roNodeJs", "sd:/dist/backend.js", {message_port: mp, node_arguments: ["--inspect=0.0.0.0:2999"], arguments: []})
+
   ' Create HTML Widget
   widget = createHTMLWidget(mp)
   widget.Show()
-  
-  ' Initialize roNodeJs with path or correct filename, whether webpack is used or not.
-  node_js = CreateObject("roNodeJs", "sd:/dist/backend.js", {message_port: mp, node_arguments: ["--inspect=0.0.0.0:2999"], arguments: []})
 
     'Event Loop test
   while true

--- a/cra-template-brightsign-dashboard/template/src/autorun.brs
+++ b/cra-template-brightsign-dashboard/template/src/autorun.brs
@@ -6,12 +6,13 @@ function main()
 	enableLDWS()
   ' Enable SSH
 	enableSSH()
-  ' Create HTML Widget
-	widget = createHTMLWidget(mp)
-	widget.Show()
   
   	' Initialize roNodeJs with path or correct filename, whether webpack is used or not.
   	node_js = CreateObject("roNodeJs", "sd:/dist/backend.js", {message_port: mp, node_arguments: ["--inspect=0.0.0.0:2999"], arguments: []})
+
+  ' Create HTML Widget
+	widget = createHTMLWidget(mp)
+	widget.Show()
 
   	'Event Loop
 	while true


### PR DESCRIPTION
## 📝 Description
<!-- Thank you for contributing to brightsign/dev-cookbook! -->

<!-- Please fill out this template the best you can, this helps us review your changes more efficiently. -->

<!-- Be sure to describe what problem you are trying to solve and how you fixed it. -->

<!-- Please link to a Github Issue if applicable. -->
**Issue**: [Url to Github Issue](https://github.com/brightsign/dev-cookbook/issues/22#issue-2289852460)

## 📋 List of Changes

<!-- Describe your changes  -->


- Please provide a concise list of the main changes.
- Change `autorun.brs` to instantiate the html after the nodejs server is started

## 🧪 Steps to Test
<!-- Carefully describe how to test your changes. -->
- If uploading the code to brightsign it will now load html correctly

1. Step 1

## Notes to the Reviewer
<!-- List any additional information for the reviewer about your changes. -->


## 📸 Screenshots

<!-- Include screenshots of your changes before/after if applicable -->


## ✔️ Dev Complete Checklist

- [ ] PR template filled out
- [ ] Change is tested by submitter
- [ ] PR follows all linting and coding standards
- [ ] Github Issue exists (if applicable)
- [ ] Team member has been assigned
- [ ] At least one commit message is in [Conventional Commit](https://www.conventionalcommits.org/) format

<!-- 

The most important prefixes you should have in mind are:

fix: which represents bug fixes, and correlates to a SemVer patch.
feat: which represents a new feature, and correlates to a SemVer minor.
feat!:, or fix!:, refactor!:, etc., which represent a breaking change (indicated by the !) and will result in a SemVer major.
-->