### PR TITLE
fix(PE-817): remove dependencies that are not supported in node v14

### DIFF
--- a/examples/node-simple-server-example/package.json
+++ b/examples/node-simple-server-example/package.json
@@ -10,8 +10,7 @@
         "format:check": "prettier . --check --config ../.prettierrc.js --cache --cache-location=../prettiercache",
         "format": "prettier . --write --config ../.prettierrc.js --cache --cache-location=../prettiercache && yarn lint --fix",
         "lint": "eslint --no-error-on-unmatched-pattern --config ../.eslintrc template/src/**/*.{js,jsx}",
-        "publish-package": "npm publish --access public",
-        "upload": "npm run build && cp src/autorun.brs dist/ && bsc local file --upload --player $npm_config_playerName --file ./dist"
+        "publish-package": "npm publish --access public"
     },
     "repository": {
         "url": "https://github.com/brightsign/dev-cookbook.git",
@@ -29,7 +28,6 @@
         "webpack-cli": "^5.1.0"
     },
     "dependencies": {
-        "@brightsign/bsc": "^2.0.2",
         "http": "^0.0.1-security",
         "node": "14.17.6"
     }

--- a/templates/html5-app-template/package.json
+++ b/templates/html5-app-template/package.json
@@ -7,7 +7,6 @@
     "start": "IS_DESKTOP=true NODE_PATH=./dist node dist/bundle.js",
     "build:dev": "npm run clean && webpack --mode development",
     "build:prod": "npm run clean && webpack --mode production --node-env=production",
-    "upload": "npm run build:dev && cp src/autorun.brs dist/ && bsc local file --upload --player $npm_config_playerName --file ./dist",
     "clean": "rm -rf dist",
     "reinstall": "npm run clean && rm -rf node_modules && npm install",
     "lint": "eslint --no-error-on-unmatched-pattern --config ../.eslintrc src/**/*.{ts,tsx}",


### PR DESCRIPTION
## 📝 Description
The bsc tool requires node version 20 or higher to run. The dev-cookbook is set to node v14. Thus, we must remove the use of the tool from the repo so there is no CI error from version incompatibility.

## 📋 List of Changes

package.json for applications that included the bsc tool in their scripts have been modified to remove said scripts. The tool is not compatible with node v14.