### PR TITLE
feat(PE-1039): Add examples to enable ldws on a player

### DIFF
--- a/examples/enable-ldws-example/README.md
+++ b/examples/enable-ldws-example/README.md
@@ -1,0 +1,161 @@
+# Enable Local Diagnostic Web Server (LDWS) Example
+
+## Introduction
+
+This example demonstrates three different methods to enable and configure the Local Diagnostic Web Server (LDWS) on a BrightSign device. The LDWS provides a web interface for device diagnostics, monitoring, and configuration that can be accessed from a web browser on the same network.
+
+## Overview
+
+The example showcases three different approaches:
+1. **BrightScript Method** - Using `roNetworkConfiguration` object (recommended for BrightScript applications)
+2. **Node.js Method** - Using the `@brightsign/dwsconfiguration` module (recommended for Node.js applications)
+3. **Registry Method** - Using registry settings (alternative approach)
+
+## Files
+
+- `autorun.brs` - BrightScript application demonstrating LDWS configuration via NetworkConfiguration
+- `index.js` - Node.js application demonstrating LDWS configuration via DWSConfiguration module
+- `autorun-nodejs.brs` - Alternative autorun file for launching the Node.js example
+- `registry.brs` - BrightScript application demonstrating LDWS configuration via registry settings
+
+## Method 1: BrightScript with roNetworkConfiguration (Recommended)
+
+### File: `autorun.brs`
+
+This method uses the `roNetworkConfiguration` object's `SetupDWS()` function to configure the LDWS settings.
+
+**Features:**
+- Direct API approach using BrightScript
+- Automatic reboot handling when required
+- Password protection with custom password
+- Immediate configuration application
+
+**How it works:**
+1. Creates a `roNetworkConfiguration` object
+2. Defines DWS configuration with password
+3. Applies configuration using `SetupDWS()`
+4. Automatically reboots the device if required
+
+### Configuration Options:
+- `open`: Sets the password for LDWS access
+- The function returns `true` if a reboot is required to apply changes
+
+## Method 2: Node.js with @brightsign/dwsconfiguration Module
+
+### File: `index.js`
+
+This method uses the Node.js `@brightsign/dwsconfiguration` module to configure LDWS settings.
+
+**Features:**
+- Modern Node.js API approach
+- Detailed configuration options
+- Support for multiple authentication methods
+- Flexible password obfuscation options
+
+**How it works:**
+1. Imports the `@brightsign/dwsconfiguration` module
+2. Creates a new DWSConfiguration instance
+3. Defines comprehensive configuration object
+4. Applies configuration using `applyConfig()`
+
+### Configuration Options:
+- `port`: HTTP port for the web server (default: 80)
+- `password.value`: Password for accessing the web interface
+- `password.obfuscated`: Whether the password is obfuscated (false = plain text)
+- `authenticationList`: Array of supported authentication methods (e.g., ["basic"])
+
+## Method 3: Registry Settings
+
+### File: `registry.brs`
+
+This method uses the BrightSign registry to configure LDWS settings.
+
+**Features:**
+- Low-level configuration approach
+- Direct registry manipulation
+- Persistent settings storage
+- Requires manual reboot or restart
+
+**How it works:**
+1. Creates a `roRegistrySection` for "networking"
+2. Writes the HTTP server port configuration
+3. Flushes changes to persistent storage
+
+### Configuration Options:
+- `http_server`: Sets the port number for the HTTP server
+
+## Running the Examples
+
+### Method 1 (BrightScript - Recommended)
+1. Copy `autorun.brs` to the root of your BrightSign player's SD card
+2. Power on or restart your BrightSign player
+3. The device will automatically configure LDWS and reboot if necessary
+4. Access the web interface at `http://<device-ip>/` with password "brightsign_ldws_2024"
+
+### Method 2 (Node.js)
+1. Ensure your BrightSign player supports Node.js applications
+2. Copy `index.js` and `autorun-nodejs.brs` to the root of your BrightSign player's SD card
+3. Rename `autorun-nodejs.brs` to `autorun.brs` (or use the provided file as a reference)
+4. Power on or restart your BrightSign player
+5. Access the web interface at `http://<device-ip>/` with password "nodejs_ldws_2024"
+
+### Method 3 (Registry)
+1. Copy `registry.brs` to the root of your BrightSign player's SD card (rename to `autorun.brs`)
+2. Power on or restart your BrightSign player
+3. Manually restart the device or network service for changes to take effect
+4. Access the web interface at `http://<device-ip>:80/`
+
+## Accessing the LDWS Web Interface
+
+Once LDWS is enabled:
+
+1. **Find the Device IP Address:**
+   - Check your router's connected devices
+   - Use BrightAuthor:connected device discovery
+   - Boot the player without an SD card to see network information
+
+2. **Access the Web Interface:**
+   - Open a web browser on a device connected to the same network
+   - Navigate to `http://<device-ip>/` (or `http://<device-ip>:80/` for Method 3)
+   - Enter the configured password when prompted
+
+3. **Available Features:**
+   - Device diagnostics and system information
+   - Network configuration and status
+   - Log file access and download
+   - System monitoring and performance metrics
+
+## Security Considerations
+
+- **Change Default Passwords:** Always use strong, unique passwords in production
+- **Network Security:** LDWS should only be enabled on trusted networks
+- **Access Control:** Consider network-level restrictions to limit access to the web interface
+- **Password Protection:** All methods support password protection - use it
+
+## Troubleshooting
+
+- **Cannot Access Web Interface:**
+  - Verify the device IP address is correct
+  - Ensure your computer and BrightSign device are on the same network
+  - Check that the correct port is being used (default: 80)
+  - Verify the password is entered correctly
+
+- **Configuration Not Applied:**
+  - Method 1: Check if device rebooted after configuration
+  - Method 2: Ensure Node.js support is available on the device
+  - Method 3: Manually restart the device or network service
+
+- **Port Conflicts:**
+  - If port 80 is in use by another application, choose a different port
+  - Update your browser URL to include the custom port number
+
+## Best Practices
+
+1. **Use Method 1 (BrightScript)** for most BrightScript-based applications
+2. **Use Method 2 (Node.js)** when developing Node.js applications
+3. **Use strong passwords** and change them regularly
+4. **Document the LDWS password** for future reference
+5. **Test access** after configuration to ensure it works correctly
+6. **Disable LDWS** in production if not needed for ongoing maintenance
+
+This example provides a foundation for implementing LDWS configuration in your BrightSign applications using the method that best fits your development approach.

--- a/examples/enable-ldws-example/autorun-nodejs.brs
+++ b/examples/enable-ldws-example/autorun-nodejs.brs
@@ -1,0 +1,14 @@
+' Autorun file for Node.js LDWS configuration example
+' This file launches the Node.js application that configures LDWS
+
+Sub Main()
+	print "Starting Node.js LDWS configuration application..."
+	
+	' Create and run Node.js application
+	nodeApp = CreateObject("roNodeApp")
+	if nodeApp <> invalid then
+		nodeApp.Run("index.js")
+	else
+		print "Error: Could not create Node.js application object"
+	end if
+End Sub

--- a/examples/enable-ldws-example/autorun.brs
+++ b/examples/enable-ldws-example/autorun.brs
@@ -1,0 +1,22 @@
+' Example: Enable LDWS and set password using BrightScript
+' This method uses roNetworkConfiguration to configure Local Diagnostic Web Server
+Sub Main()
+	' Create network configuration object
+	nc = CreateObject("roNetworkConfiguration", 0)
+
+	' Enable LDWS and set the password
+	' The "open" field sets the password for web interface access
+	dwsConfig = { open: "brightsign_ldws_2024" }
+	
+	print "Configuring Local Diagnostic Web Server..."
+	rebootRequired = nc.SetupDWS(dwsConfig)
+
+	' Reboot if required for changes to take effect
+	if rebootRequired then
+		print "Reboot required. Restarting device..."
+		RebootSystem()
+	else
+		print "LDWS configuration applied successfully!"
+		print "Access web interface at http://<device-ip>/ with password: brightsign_ldws_2024"
+	end if
+End Sub

--- a/examples/enable-ldws-example/index.js
+++ b/examples/enable-ldws-example/index.js
@@ -1,0 +1,28 @@
+// Example: Enable LDWS using Node.js @brightsign/dwsconfiguration module
+// This method provides more detailed configuration options for LDWS
+
+const DWSConfiguration = require("@brightsign/dwsconfiguration");
+
+console.log("Configuring Local Diagnostic Web Server via Node.js...");
+
+// Create DWS configuration instance
+const dwsConfig = new DWSConfiguration();
+
+// Define comprehensive LDWS configuration
+const config = {
+	port: 80,                          // HTTP port for web server
+	password: {
+		value: "nodejs_ldws_2024",     // Password for web interface access
+		obfuscated: false              // Password is in plain text (not obfuscated)
+	},
+	authenticationList: ["basic"]      // Support basic HTTP authentication
+};
+
+try {
+	// Apply the LDWS configuration
+	dwsConfig.applyConfig(config);
+	console.log("LDWS configuration applied successfully!");
+	console.log(`Access web interface at http://<device-ip>:${config.port}/ with password: ${config.password.value}`);
+} catch (error) {
+	console.error("Failed to configure LDWS:", error.message);
+}

--- a/examples/enable-ldws-example/registry.brs
+++ b/examples/enable-ldws-example/registry.brs
@@ -1,0 +1,27 @@
+' Example: Enable LDWS using registry settings
+' This method uses direct registry manipulation to configure LDWS
+' Note: This method requires manual device restart for changes to take effect
+
+function Main()
+	print "Configuring LDWS via registry settings..."
+	
+	' Create registry section for networking configuration
+	registrySection = CreateObject("roRegistrySection", "networking")
+
+	if type(registrySection) = "roRegistrySection" then 
+		' Set HTTP server port for LDWS
+		' Port 80 is the default HTTP port
+		registrySection.Write("http_server", "80")
+		
+		print "Registry setting applied: http_server = 80"
+		print "Manual device restart required for changes to take effect"
+		print "After restart, access web interface at http://<device-ip>:80/"
+	else
+		print "Error: Could not create registry section"
+	end if
+
+	' Flush changes to persistent storage
+	registrySection.Flush()
+	
+	return 0
+end function


### PR DESCRIPTION
## 📝 Description
This branch provides clear documentation and updated code samples that demonstrate three different methods to enable the Local Diagnostic Web Server (LDWS) on BrightSign devices: using BrightScript, Node.js, and direct registry settings. The example helps developers choose and implement the best approach for enabling LDWS in their projects.

**Issue**: [Url to Jira Issue](https://brightsign.atlassian.net/browse/PE-1039)

## 📋 List of Changes

- README.md: Explains the three different methods to enable the Local Diagnostic Web Server (LDWS) and provides setup instructions.
- autorun.brs: BrightScript example that enables LDWS using the roNetworkConfiguration API (recommended for BrightScript apps).
- index.js: Node.js example that enables LDWS using the @brightsign/dwsconfiguration module (for Node.js-based apps).
- autorun-nodejs.brs: BrightScript autorun file that launches the Node.js example on the device.
- registry.brs: BrightScript example that enables LDWS by directly writing to the device registry (alternative, low-level approach).

## 🧪 Steps to Test

Run each example on your player.

## ✔️ Dev Complete Checklist

- [x] PR template filled out
- [ ] Change is tested by submitter
- [ ] PR follows all linting and coding standards
- [x] Team member has been assigned
- [x] At least one commit message is in [Conventional Commit](https://www.conventionalcommits.org/) format
