### PR TITLE
fix(PE-1008): Fixed broken linting paths, reformatted linting errors

### DIFF
--- a/examples/node-simple-server-example/package.json
+++ b/examples/node-simple-server-example/package.json
@@ -9,7 +9,7 @@
         "build": "webpack --mode=development",
         "format:check": "prettier . --check --config ../.prettierrc.js --cache --cache-location=../prettiercache",
         "format": "prettier . --write --config ../.prettierrc.js --cache --cache-location=../prettiercache && yarn lint --fix",
-        "lint": "eslint --no-error-on-unmatched-pattern --config ../.eslintrc template/src/**/*.{js,jsx}",
+        "lint": "eslint --no-error-on-unmatched-pattern --config ../../.eslintrc src/**/*.{js,jsx}",
         "publish-package": "npm publish --access public"
     },
     "repository": {

--- a/examples/node-simple-server-example/src/app.js
+++ b/examples/node-simple-server-example/src/app.js
@@ -9,33 +9,38 @@ function app() {
 
         const server = http.createServer((req, res) => {
             // Serve device info on /api/device-info
-            if (req.url === '/api/device-info') {
+            if (req.url === "/api/device-info") {
                 res.setHeader("Content-Type", "application/json");
                 const jsonResponse = JSON.stringify(di);
-                return res.end(jsonResponse);
+                res.end(jsonResponse);
+                return;
             }
 
             // Serve static files from /storage/sd/
-            const filePath = path.join('/storage/sd', req.url === '/' ? 'index.html' : req.url);
+            const filePath = path.join(
+                "/storage/sd",
+                req.url === "/" ? "index.html" : req.url
+            );
             fs.readFile(filePath, (err, content) => {
                 if (err) {
                     res.writeHead(404);
-                    res.end('File not found');
+                    res.end("File not found");
                     return;
                 }
 
                 // Set content type based on file extension
                 const ext = path.extname(filePath);
-                const contentType = {
-                    '.html': 'text/html',
-                    '.js': 'text/javascript',
-                    '.css': 'text/css',
-                    '.json': 'application/json',
-                    '.png': 'image/png',
-                    '.jpg': 'image/jpeg',
-                }[ext] || 'text/plain';
+                const contentType =
+                    {
+                        ".html": "text/html",
+                        ".js": "text/javascript",
+                        ".css": "text/css",
+                        ".json": "application/json",
+                        ".png": "image/png",
+                        ".jpg": "image/jpeg",
+                    }[ext] || "text/plain";
 
-                res.writeHead(200, { 'Content-Type': contentType });
+                res.writeHead(200, { "Content-Type": contentType });
                 res.end(content);
             });
         });

--- a/examples/node-simple-server-example/src/app.test.js
+++ b/examples/node-simple-server-example/src/app.test.js
@@ -1,6 +1,5 @@
 const http = require("http");
-const diClass = require("@brightsign/deviceinfo");
-const main = require("./app");
+const main = require("./app.js");
 
 describe("HTTP Server Response", () => {
     let server;
@@ -16,35 +15,43 @@ describe("HTTP Server Response", () => {
         }
     });
 
-    it("should respond with JSON containing mocked device info", (done) => {
-        http.get(`http://localhost:${port}/api/device-info`, (res) => {
-            expect(res.statusCode).toBe(200);
-            expect(res.headers["content-type"]).toBe("application/json");
+    it("should respond with JSON containing mocked device info", async () => {
+        const response = await new Promise((resolve, reject) => {
+            http.get(`http://localhost:${port}/api/device-info`, (res) => {
+                expect(res.statusCode).toBe(200);
+                expect(res.headers["content-type"]).toBe("application/json");
 
-            let data = "";
-            res.on("data", (chunk) => {
-                data += chunk;
-            });
-            res.on("end", () => {
-                const receivedData = JSON.parse(data);
+                let data = "";
+                res.on("data", (chunk) => {
+                    data += chunk;
+                });
+                res.on("end", () => {
+                    const receivedData = JSON.parse(data);
 
-                // Verify that the response contains the mocked device info
-                expect(receivedData.model).toBe("MockModel");
-                expect(receivedData.osVersion).toBe("MockOSVersion");
-                expect(receivedData.serialNumber).toBe("MockSerialNumber");
-                done();
+                    // Verify that the response contains the mocked device info
+                    expect(receivedData.model).toBe("MockModel");
+                    expect(receivedData.osVersion).toBe("MockOSVersion");
+                    expect(receivedData.serialNumber).toBe("MockSerialNumber");
+                    resolve(receivedData);
+                });
+            }).on("error", (err) => {
+                reject(err);
             });
-        }).on("error", (err) => {
-            done(err);
         });
+        expect(response).toBeDefined();
     });
 
-    it("should return 404 for non-existent files", (done) => {
-        http.get(`http://localhost:${port}/non-existent-file.txt`, (res) => {
-            expect(res.statusCode).toBe(404);
-            done();
-        }).on("error", (err) => {
-            done(err);
+    it("should return 404 for non-existent files", async () => {
+        await new Promise((resolve, reject) => {
+            http.get(
+                `http://localhost:${port}/non-existent-file.txt`,
+                (res) => {
+                    expect(res.statusCode).toBe(404);
+                    resolve();
+                }
+            ).on("error", (err) => {
+                reject(err);
+            });
         });
     });
 });

--- a/examples/node-simple-server-example/src/index.js
+++ b/examples/node-simple-server-example/src/index.js
@@ -1,5 +1,5 @@
-import app from "./app";
+import app from "./app.js";
 
 app().catch((err) => {
-    console.error("Error running server" + err);
+    console.error(`Error running server: ${err}`);
 });

--- a/templates/cra-template-brightsign-app/package.json
+++ b/templates/cra-template-brightsign-app/package.json
@@ -20,7 +20,7 @@
         "test": "jest --config jest.config.js template/src/",
         "format:check": "prettier . --check --config ../.prettierrc.js --cache --cache-location=../prettiercache",
         "format": "prettier . --write --config ../.prettierrc.js --cache --cache-location=../prettiercache && yarn lint --fix",
-        "lint": "eslint --no-error-on-unmatched-pattern --config ../.eslintrc template/src/**/*.{js,jsx}",
+        "lint": "eslint --no-error-on-unmatched-pattern --config ../../.eslintrc template/src/**/*.{js,jsx}",
         "publish-package": "npm publish --access public"
     }
 }

--- a/templates/cra-template-brightsign-app/template/src/server/index.js
+++ b/templates/cra-template-brightsign-app/template/src/server/index.js
@@ -6,10 +6,13 @@ const app = express();
 
 app.use(express.json());
 app.use(express.static(path));
-app.use(function (req, res, next) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+app.use((req, res, next) => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.setHeader(
+        "Access-Control-Allow-Methods",
+        "GET, POST, PUT, DELETE, OPTIONS"
+    );
     next();
 });
 

--- a/templates/cra-template-brightsign-dashboard/package.json
+++ b/templates/cra-template-brightsign-dashboard/package.json
@@ -20,7 +20,7 @@
         "test": "jest --config jest.config.js template/src/",
         "format:check": "prettier . --check --config ../.prettierrc.js --cache --cache-location=../prettiercache",
         "format": "prettier . --write --config ../.prettierrc.js --cache --cache-location=../prettiercache && yarn lint --fix",
-        "lint": "eslint --no-error-on-unmatched-pattern --config ../.eslintrc template/src/**/*.{js,jsx}",
+        "lint": "eslint --no-error-on-unmatched-pattern --config ../../.eslintrc template/src/**/*.{js,jsx}",
         "publish-package": "npm publish --access public"
     }
 }

--- a/templates/html5-app-template/.eslintrc
+++ b/templates/html5-app-template/.eslintrc
@@ -1,0 +1,30 @@
+{
+  "extends": [
+    "prettier"
+  ],
+  "plugins": ["prettier", "@typescript-eslint"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "rules": {
+    "prettier/prettier": ["warn"],
+    "import/no-unresolved": ["off"],
+    "import/no-extraneous-dependencies": ["off"],
+    "no-console": ["off"],
+    "import/prefer-default-export": ["off"],
+    "import/extensions": ["off"],
+    "import/order": ["off"],
+    "import/newline-after-import": ["off"],
+    "no-use-before-define": ["off"],
+    "arrow-body-style": ["off"],
+    "eqeqeq": ["off"],
+    "prefer-destructuring": ["off"],
+    "@typescript-eslint/no-unused-vars": ["error"]
+  },
+  "env": {
+    "browser": true,
+    "node": true
+  }
+}

--- a/templates/html5-app-template/package.json
+++ b/templates/html5-app-template/package.json
@@ -9,7 +9,7 @@
     "build:prod": "npm run clean && webpack --mode production --node-env=production",
     "clean": "rm -rf dist",
     "reinstall": "npm run clean && rm -rf node_modules && npm install",
-    "lint": "eslint --no-error-on-unmatched-pattern --config ../.eslintrc src/**/*.{ts,tsx}",
+    "lint": "eslint --no-error-on-unmatched-pattern --config .eslintrc src/**/*.{ts,tsx}",
     "lint:fix": "eslint --fix src --ext js,jsx,ts,tsx,json",
     "format:check": "prettier 'src/**/*.{js,jsx,ts,tsx,css,md,json}' --check --config ../.prettierrc.js --cache --cache-location=../prettiercache",
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,md,json}' --config ../.prettierrc.js && npm run lint",


### PR DESCRIPTION
## 📝 Description
Linting fails in the repository now that we’ve introduced a typescript application. We need to resolve this by either modifying the current linting config to support typescript applications, or if that doesn’t work, we should design each app to manage its own linting.

**Issue**: [Url to Jira Issue](https://brightsign.atlassian.net/browse/PE-1008)

## 📋 List of Changes

- Fixed broken paths
- Reformatted linting issues


## 🧪 Steps to Test

1. Execute `npm run lint` at the root of the project

## ✔️ Dev Complete Checklist

- [x] PR template filled out
- [x] Change is tested by submitter
- [x] PR follows all linting and coding standards
- [x] Github Issue exists (if applicable)
- [x] Team member has been assigned
- [x] At least one commit message is in [Conventional Commit](https://www.conventionalcommits.org/) format