### PR TITLE
feat(PE-1271): seamless-video-switching; early start and script tag fix

### DIFF
--- a/examples/seamless-video-switching/index.html
+++ b/examples/seamless-video-switching/index.html
@@ -52,7 +52,7 @@
     <div id="video-container">
       <video id="video-player-1" preload="auto" autoplay></video>
       <video id="video-player-2" class="hidden" preload="auto"></video>
-      </video>
     </div>
+    <script src="index.js"></script>
   </body>
 </html>

--- a/examples/seamless-video-switching/index.js
+++ b/examples/seamless-video-switching/index.js
@@ -9,52 +9,93 @@ let currentVideoIndex = 0;
 let visibleVideoPlayer = 1;
 let videoFiles = [];
 
-// Helper function to get player element by number
 function getPlayer(playerNumber) {
   return document.getElementById(`video-player-${playerNumber}`);
 }
 
-// Helper function to get the currently visible and hidden players
 function getPlayers() {
   const visible = getPlayer(visibleVideoPlayer);
   const hidden = getPlayer(visibleVideoPlayer === 1 ? 2 : 1);
   return { visible, hidden };
 }
 
+function preloadNextVideo() {
+  const nextVideoIndex = (currentVideoIndex + 1) % videoFiles.length;
+  const { hidden } = getPlayers();
+  hidden.pause();
+  hidden.currentTime = 0;
+  hidden.muted = true;
+  hidden.src = `${assetsFolder}/${videoFiles[nextVideoIndex]}`;
+  hidden.load();
+
+  hidden.addEventListener('canplay', () => {
+    hidden.play().then(() => { hidden.pause(); hidden.currentTime = 0; }).catch(() => {});
+  }, { once: true });
+}
+
+// Start hidden player 0.5s before end so it's already playing when the swap happens
+function armEarlyStart() {
+  const { visible } = getPlayers();
+  visible.addEventListener('timeupdate', function onNearEnd() {
+    if (visible.duration - visible.currentTime <= 0.5) {
+      visible.removeEventListener('timeupdate', onNearEnd);
+      getPlayers().hidden.play().catch(() => {});
+    }
+  });
+}
+
+function switchToNextVideo() {
+  currentVideoIndex = (currentVideoIndex + 1) % videoFiles.length;
+  const { visible: currentPlayer, hidden: nextPlayer } = getPlayers();
+
+  const doSwap = () => {
+    currentPlayer.pause();
+    currentPlayer.muted = true;
+    currentPlayer.classList.add('hidden');
+    nextPlayer.muted = false;
+    nextPlayer.classList.remove('hidden');
+    visibleVideoPlayer = visibleVideoPlayer === 1 ? 2 : 1;
+    preloadNextVideo();
+    armEarlyStart();
+  };
+
+  // If early start worked, swap is instant; otherwise wait for playing
+  if (!nextPlayer.paused) {
+    doSwap();
+  } else {
+    nextPlayer.play().catch(e => console.error('Play error:', e));
+    nextPlayer.addEventListener('playing', doSwap, { once: true });
+  }
+}
+
 async function main() {
   console.log('main() - App ready!');
 
   try {
-    // Load and filter video files
     videoFiles = fs.readdirSync(`${rootStoragePath}/${assetsFolder}`);
     videoFiles = videoFiles.filter(filename => !filename.startsWith('.'));
     videoFiles.sort();
-    
-    // console.log('Video files:', videoFiles);
-    
+
     if (videoFiles.length === 0) {
       console.error(`No video files found in ${rootStoragePath}/${assetsFolder}`);
       return;
     }
-    
+
     const player1 = getPlayer(1);
     const player2 = getPlayer(2);
-    
-    // Initialize first video
+
     player1.src = `${assetsFolder}/${videoFiles[0]}`;
     player1.currentTime = 0;
-    player1.muted = false; // Ensure audio is enabled for first player
-    player2.muted = true;  // Mute the second player initially
-    console.log('Player 1 loaded:', videoFiles[0]);
-    
-    // Set up video ended listeners for both players
+    player1.muted = false;
+    player2.muted = true;
+
     player1.addEventListener('ended', () => switchToNextVideo());
     player2.addEventListener('ended', () => switchToNextVideo());
-    
-    // Preload next video once first video starts playing
+
     player1.addEventListener('playing', () => {
       console.log('Player 1 playing');
       preloadNextVideo();
+      armEarlyStart();
     }, { once: true });
 
   } catch (e) {
@@ -62,51 +103,6 @@ async function main() {
   }
 }
 
-// Preload the next video in the hidden player
-function preloadNextVideo() {
-  const nextVideoIndex = (currentVideoIndex + 1) % videoFiles.length;
-  const { hidden } = getPlayers();
-  const filePath = `${assetsFolder}/${videoFiles[nextVideoIndex]}`;
-
-  console.log(`Preloading: ${videoFiles[nextVideoIndex]}`);
-  
-  // Reset and load the next video
-  hidden.pause();
-  hidden.currentTime = 0;
-  hidden.muted = true; // Ensure hidden player is muted
-  hidden.src = filePath;
-  hidden.load();
-}
-
-// Switch to the next video seamlessly
-function switchToNextVideo() {
-  currentVideoIndex = (currentVideoIndex + 1) % videoFiles.length;
-  const { visible: currentPlayer, hidden: nextPlayer } = getPlayers();
-  
-  console.log(`Switching to: ${videoFiles[currentVideoIndex]}`);
-  
-  // Ensure next player starts from beginning
-  nextPlayer.currentTime = 0;
-  
-  // Start playing the next video (while still hidden)
-  nextPlayer.play().catch(e => console.error('Play error:', e));
-  
-  // Switch visibility and audio immediately - the video is already preloaded
-  currentPlayer.pause();
-  currentPlayer.muted = true; // Mute the outgoing player
-  currentPlayer.classList.add('hidden');
-  
-  nextPlayer.muted = false; // Unmute the incoming player
-  nextPlayer.classList.remove('hidden');
-  
-  // Toggle which player is visible
-  visibleVideoPlayer = visibleVideoPlayer === 1 ? 2 : 1;
-  
-  // Preload the next video in the now-hidden player
-  preloadNextVideo();
-}
-
-// Call main when DOM is ready
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', main);
 } else {


### PR DESCRIPTION
## 📝 Description
- Fixes a bug where index.js was never loaded — index.html was missing the <script src="index.js"> tag entirely
- Replaces the fire-and-forget play() at switch time with an early start strategy: the hidden player begins playing 0.5s before the current video ends, so the swap on ended is instant with no gap                                                                            
- Pre-warms the decode pipeline during preload (canplay → brief play → pause at frame 0) so the hidden player starts near-instantly when early start triggers
- switchToNextVideo falls back to awaiting the playing event before swapping if early start didn't complete in time, preventing a visibility swap on a black frame

**Behavior**                                                                                                                                                                                                                                                                                                                                                 
- Video 1 plays to its natural end. The hidden player begins playing (muted) within the last 0.5s of video 1. On ended, if the hidden player is already in a playing state the swap is immediate. The 0.5s window is within the acceptable content budget — no content from video 2's beginning is skipped from the viewer's perspective at the point of the cut.

<!-- Please link to a Github Issue if applicable. -->
**Issue**: [Url to Jira Issue](https://brightsign.atlassian.net/browse/PE-1271)

## 📋 List of Changes

<!-- Describe your changes  -->

- Please provide a concise list of the main changes.


## ✔️ Dev Complete Checklist

- [x] PR template filled out
- [] Change is tested by submitter (Not tested on every set of players and content I want yet)
- [x] PR follows all linting and coding standards
- [ ] Github Issue exists (if applicable)
- [x] Team member has been assigned
- [x] At least one commit message is in [Conventional Commit](https://www.conventionalcommits.org/) format