### PR TITLE
fix(PE-1451): correct MatchFiles usage in autozip.brs DoesFileExist

### DIFF
--- a/examples/node-14/autorun-zip-package/setup-files/autozip.brs
+++ b/examples/node-14/autorun-zip-package/setup-files/autozip.brs
@@ -64,8 +64,23 @@ function main()
 end function
 
 ' Check if a file exists at the specified path
+' MatchFiles() requires a directory as its first argument and a
+' separator-free pattern as its second, so the path must be split
+' into its directory and filename parts before matching.
 function DoesFileExist(filePath$ as string) as boolean
-    fileInfo = MatchFiles(filePath$, filePath$)
+    dirPath$ = "SD:/"
+    fileName$ = filePath$
+    lastSlashPos% = 0
+    for i% = 1 to Len(filePath$)
+        if Mid(filePath$, i%, 1) = "/" then
+            lastSlashPos% = i%
+        end if
+    next
+    if lastSlashPos% > 0 then
+        dirPath$ = Left(filePath$, lastSlashPos%)
+        fileName$ = Mid(filePath$, lastSlashPos% + 1)
+    end if
+    fileInfo = MatchFiles(dirPath$, fileName$)
     if fileInfo.Count() > 0 then
         return true
     end if


### PR DESCRIPTION
## 📝 Description
<!-- Thank you for contributing to brightsign/dev-cookbook! -->

`DoesFileExist()` in the autorun.zip example's `autozip.brs` always returned `false`, even when the target file existed, because it called `MatchFiles(filePath$, filePath$)` with the full file path as both arguments. Per the BrightSign `MatchFiles(path, pattern_in)` contract, the first argument must be a directory and the pattern must not contain a directory separator, otherwise it returns zero results. This broke the zip-exists and already-extracted checks that drive the whole extraction flow.

**Issue**: [PE-1451](https://brightsign.atlassian.net/browse/PE-1451)

## 📋 List of Changes

- `DoesFileExist()` now splits the incoming path into its directory and filename parts and calls `MatchFiles(dirPath$, fileName$)` correctly.

## 🧪 Steps to Test

1. Build the `autorun-zip-package` example and place `autorun.zip` at the root of an SD card.
2. Boot a player (BrightSignOS 7.0.60+) with the card inserted.
3. Confirm the debugger log shows the zip is detected, extracted, and renamed to `autorun.zip.done`, and the player reboots into the extracted app instead of failing the `DoesFileExist` check.

## Notes to the Reviewer
<!-- List any additional information for the reviewer about your changes. -->
Root cause was confirmed against the BrightSign developer docs (`Global Functions > MatchFiles`) and against a debugger repro from a partner (Guillaume Proux) showing `MatchFiles("SD:", "autorun.zip")` succeeds while `MatchFiles("SD:/autorun.zip", "SD:/autorun.zip")` does not.

## 📸 Screenshots

<!-- Include screenshots of your changes before/after if applicable -->
N/A

## ✔️ Dev Complete Checklist

- [x] PR template filled out
- [ ] Change is tested by submitter
- [x] PR follows all linting and coding standards
- [x] Github Issue exists (if applicable)
- [x] Team member has been assigned
- [x] At least one commit message is in [Conventional Commit](https://www.conventionalcommits.org/) format


[PE-1451]: https://brightsign.atlassian.net/browse/PE-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ